### PR TITLE
Read dismissalDate parameter

### DIFF
--- a/ios/Sources/LiveActivityPlugin/LiveActivity.swift
+++ b/ios/Sources/LiveActivityPlugin/LiveActivity.swift
@@ -55,7 +55,7 @@ import Foundation
                 var dismissalPolicy: ActivityUIDismissalPolicy = .default
 
                 if let dismissalTimestamp = dismissalDate {
-                    let date = Date(timeIntervalSince1970: dismissalTimestamp.doubleValue / 1000)
+                    let date = Date(timeIntervalSince1970: dismissalTimestamp.doubleValue)
                     dismissalPolicy = .after(date)
                 }
 

--- a/ios/Sources/LiveActivityPlugin/LiveActivity.swift
+++ b/ios/Sources/LiveActivityPlugin/LiveActivity.swift
@@ -48,11 +48,22 @@ import Foundation
             }
     }
 
-    @objc public func end(id: String, content: [String: String]) async {
+    @objc public func end(id: String, content: [String: String], dismissalDate: NSNumber?) async {
             if let activity = activities[id] {
                 let state = GenericAttributes.ContentState(values: content)
+                
+                var dismissalPolicy: ActivityUIDismissalPolicy = .default
+
+                if let dismissalTimestamp = dismissalDate {
+                    let date = Date(timeIntervalSince1970: dismissalTimestamp.doubleValue / 1000)
+                    dismissalPolicy = .after(date)
+                }
+
                 await activity.end(
-                    ActivityContent(state: state, staleDate: nil), dismissalPolicy: .default)
+                    ActivityContent(state: state, staleDate: nil),
+                    dismissalPolicy: dismissalPolicy
+                )
+                
                 activities.removeValue(forKey: id)
             }
     }

--- a/ios/Sources/LiveActivityPlugin/LiveActivityPlugin.swift
+++ b/ios/Sources/LiveActivityPlugin/LiveActivityPlugin.swift
@@ -60,12 +60,7 @@ public class LiveActivityPlugin: CAPPlugin, CAPBridgedPlugin {
             return
         }
 
-        var dismissalDate: NSNumber? = nil
-
-        if let dismissalTimestamp = call.getDouble("dismissalDate") {
-            dismissalDate = NSNumber(value: dismissalTimestamp)
-        }
-
+        let dismissalDate = call.getDouble("dismissalDate").map(NSNumber.init(value:))
         Task {
             await implementation.end(id: id, content: contentState, dismissalDate: dismissalDate)
             call.resolve()

--- a/ios/Sources/LiveActivityPlugin/LiveActivityPlugin.swift
+++ b/ios/Sources/LiveActivityPlugin/LiveActivityPlugin.swift
@@ -60,8 +60,14 @@ public class LiveActivityPlugin: CAPPlugin, CAPBridgedPlugin {
             return
         }
 
+        var dismissalDate: NSNumber? = nil
+
+        if let dismissalTimestamp = call.getDouble("dismissalDate") {
+            dismissalDate = NSNumber(value: dismissalTimestamp)
+        }
+
         Task {
-            await implementation.end(id: id, content: contentState)
+            await implementation.end(id: id, content: contentState, dismissalDate: dismissalDate)
             call.resolve()
         }
     }


### PR DESCRIPTION
## Issue
The plugin currently does not read parameter `dismissalDate`, and the dismissal policy is hard coded to `.default`.

## Fix
Modify to read dismissalDate and set dismissal policy to `.after(dismissalDate)` when provided. Fallback to `.default`.