### PR TITLE
feat: add caching for activity push tokens and implement retrieval method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - **Native update token registration:** Added `setUpdateTokenEndpoint(...)` so iOS can POST per-activity update tokens to a configured backend endpoint while keeping the existing `liveActivityPushToken` event unchanged. ([#14](https://github.com/kisimediaDE/capacitor-live-activity/issues/14))
+- **Cached activity push tokens:** Added `getActivityPushTokens(...)` so JS can retrieve per-activity update tokens that iOS received while the WebView was not running, covering push-to-start flows where the listener missed the event. ([#13](https://github.com/kisimediaDE/capacitor-live-activity/issues/13))
 - **Immediate dismissal policy:** Added `dismissalPolicy: "immediate"` support for ending Live Activities immediately, and iOS now keeps ended activities available via `listActivities()` so persisted ended activities can be dismissed after app restart. ([#15](https://github.com/kisimediaDE/capacitor-live-activity/issues/15))
 - **Example App:** Added dismissal policy controls to the Live Activity demos, including explicit system default, immediate, after timestamp, and legacy unspecified modes.
 - **Example Server:** Added `/live-activity/register-token` to demonstrate receiving native update token registrations.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - **Cached activity push tokens:** Added `getActivityPushTokens(...)` so JS can retrieve per-activity update tokens that iOS received while the WebView was not running, covering push-to-start flows where the listener missed the event. ([#13](https://github.com/kisimediaDE/capacitor-live-activity/issues/13))
 - **Immediate dismissal policy:** Added `dismissalPolicy: "immediate"` support for ending Live Activities immediately, and iOS now keeps ended activities available via `listActivities()` so persisted ended activities can be dismissed after app restart. ([#15](https://github.com/kisimediaDE/capacitor-live-activity/issues/15))
 - **Example App:** Added dismissal policy controls to the Live Activity demos, including explicit system default, immediate, after timestamp, and legacy unspecified modes.
+- **Example App:** Added Push demo controls for native update token endpoint registration and loading cached per-activity push tokens.
 - **Example Server:** Added `/live-activity/register-token` to demonstrate receiving native update token registrations.
 
 ## [8.1.0] - 2026-01-26

--- a/README.md
+++ b/README.md
@@ -279,6 +279,13 @@ The endpoint receives:
 }
 ```
 
+If the app was not foregrounded when iOS emitted the token, retrieve the cached native token later:
+
+```typescript
+const { items } = await LiveActivity.getActivityPushTokens({ id: 'delivery-123' });
+const latestToken = items.at(-1)?.token;
+```
+
 ## 📱 Example App
 
 This plugin includes a fully functional demo app under the [`example-app/`](./example-app) directory.
@@ -307,6 +314,7 @@ The demo is designed to run on real iOS devices and showcases multiple Live Acti
 * [`listActivities()`](#listactivities)
 * [`observePushToStartToken()`](#observepushtostarttoken)
 * [`setUpdateTokenEndpoint(...)`](#setupdatetokenendpoint)
+* [`getActivityPushTokens(...)`](#getactivitypushtokens)
 * [`addListener('liveActivityPushToken', ...)`](#addlistenerliveactivitypushtoken-)
 * [`addListener('liveActivityPushToStartToken', ...)`](#addlistenerliveactivitypushtostarttoken-)
 * [`addListener('liveActivityUpdate', ...)`](#addlistenerliveactivityupdate-)
@@ -536,6 +544,30 @@ logged natively and do not reject `startActivityWithPush`.
 --------------------
 
 
+### getActivityPushTokens(...)
+
+```typescript
+getActivityPushTokens(options?: { id?: string | undefined; } | undefined) => Promise<GetActivityPushTokensResult>
+```
+
+Return cached per-activity update tokens that iOS has already received.
+
+Use this as a fallback when `liveActivityPushToken` was emitted while the
+WebView was not running, for example after a Live Activity was started via
+push-to-start in the background. Pass `id` to filter by your logical
+activity id.
+
+| Param         | Type                          |
+| ------------- | ----------------------------- |
+| **`options`** | <code>{ id?: string; }</code> |
+
+**Returns:** <code>Promise&lt;<a href="#getactivitypushtokensresult">GetActivityPushTokensResult</a>&gt;</code>
+
+**Since:** 8.2.0
+
+--------------------
+
+
 ### addListener('liveActivityPushToken', ...)
 
 ```typescript
@@ -695,11 +727,13 @@ Options for native per-activity update token registration.
 | **`headers`** | <code><a href="#record">Record</a>&lt;string, string&gt;</code> | Optional HTTP headers added to the registration POST for the current app session only. Headers are not persisted; avoid long-lived secrets here.                        |
 
 
-#### PluginListenerHandle
+#### GetActivityPushTokensResult
 
-| Prop         | Type                                      |
-| ------------ | ----------------------------------------- |
-| **`remove`** | <code>() =&gt; Promise&lt;void&gt;</code> |
+Result of listing cached per-activity update tokens.
+
+| Prop        | Type                          |
+| ----------- | ----------------------------- |
+| **`items`** | <code>PushTokenEvent[]</code> |
 
 
 #### PushTokenEvent
@@ -711,6 +745,13 @@ Event payload for per-activity live-activity push tokens.
 | **`id`**         | <code>string</code> | Your logical ID (the one you passed to start).              |
 | **`activityId`** | <code>string</code> | System activity identifier (Activity.id).                   |
 | **`token`**      | <code>string</code> | Hex-encoded APNs/FCM live activity token for this activity. |
+
+
+#### PluginListenerHandle
+
+| Prop         | Type                                      |
+| ------------ | ----------------------------------------- |
+| **`remove`** | <code>() =&gt; Promise&lt;void&gt;</code> |
 
 
 #### PushToStartTokenEvent

--- a/example-app/src/demos/push/demo.html
+++ b/example-app/src/demos/push/demo.html
@@ -36,6 +36,8 @@
           <button onclick="getFcm()">🎟️ Get FCM Token</button>
           <button onclick="observeP2S()">🔑 Observe Push-to-Start Token</button>
           <button onclick="observeActivityTokens()">🧩 Observe Activity Push Tokens</button>
+          <button onclick="configureUpdateTokenEndpoint()">🌐 Register Token Endpoint</button>
+          <button onclick="loadCachedActivityTokens()">📥 Load Cached Activity Token</button>
         </div>
         <textarea id="fcm" placeholder="FCM Token"></textarea>
         <textarea id="p2s" placeholder="Push-to-Start Token (hex)"></textarea>

--- a/example-app/src/demos/push/demo.js
+++ b/example-app/src/demos/push/demo.js
@@ -88,6 +88,36 @@ window.observeActivityTokens = async () => {
   }
 };
 
+window.configureUpdateTokenEndpoint = async () => {
+  try {
+    await LiveActivity.setUpdateTokenEndpoint({
+      url: `${base()}/live-activity/register-token`,
+    });
+    log('🌐 Native update token endpoint registered.');
+  } catch (e) {
+    log('❌ configureUpdateTokenEndpoint: ' + e.message);
+  }
+};
+
+window.loadCachedActivityTokens = async () => {
+  try {
+    const attrs = JSON.parse($('attrs').value || '{}');
+    const id = attrs.id;
+    const { items } = await LiveActivity.getActivityPushTokens(id ? { id } : undefined);
+    const latest = items.at(-1);
+    if (!latest) {
+      log('ℹ️ No cached activity push token found.');
+      return;
+    }
+
+    $('push').value = latest.token;
+    localStorage.setItem(LS.PUSH, latest.token);
+    log(`📥 Cached activity push token for "${latest.id}" loaded.`);
+  } catch (e) {
+    log('❌ loadCachedActivityTokens: ' + e.message);
+  }
+};
+
 function base() { return ( $('base-url').value || '' ).trim(); }
 function fcm() { return ( $('fcm').value || '' ).trim(); }
 function p2s() { return ( $('p2s').value || '' ).trim(); }

--- a/example-app/src/demos/push/demo.js
+++ b/example-app/src/demos/push/demo.js
@@ -18,7 +18,7 @@ window.onload = () => {
   $('push').value = localStorage.getItem(LS.PUSH) || '';
 
   // sinnvolle Defaults
-  $('attributes-type').value = 'LiveActivityWidgetExtension.GenericAttributes';
+  $('attributes-type').value = 'GenericAttributes';
   $('attrs').value = JSON.stringify({ id: 'demo-remote', staticValues: { type: 'delivery', title: '📦 Delivery' } }, null, 2);
   $('content').value = JSON.stringify({ status: 'Starting…', eta: '20 min' }, null, 2);
   $('alert').value = JSON.stringify({ title: 'Live Activity', body: 'Started remotely' }, null, 2);

--- a/ios/Sources/LiveActivityPlugin/LiveActivity.swift
+++ b/ios/Sources/LiveActivityPlugin/LiveActivity.swift
@@ -577,7 +577,6 @@ private struct CachedUpdateToken: Codable {
         return Dictionary(
             uniqueKeysWithValues: legacyTokens.compactMap { activityId, token in
                 guard let id = token["id"],
-                    let tokenActivityId = token["activityId"],
                     let tokenValue = token["token"]
                 else {
                     return nil
@@ -587,7 +586,7 @@ private struct CachedUpdateToken: Codable {
                     activityId,
                     CachedUpdateToken(
                         id: id,
-                        activityId: tokenActivityId,
+                        activityId: activityId,
                         token: tokenValue,
                         cachedAt: 0
                     )

--- a/ios/Sources/LiveActivityPlugin/LiveActivity.swift
+++ b/ios/Sources/LiveActivityPlugin/LiveActivity.swift
@@ -7,6 +7,8 @@ private let EVT_PUSH_TO_START_TOKEN = "liveActivityPushToStartToken"
 private let EVT_ACTIVITY_UPDATE = "liveActivityUpdate"
 private let UPDATE_TOKEN_ENDPOINT_KEY =
     "de.kisimedia.capacitor-live-activity.updateTokenEndpoint"
+private let CACHED_UPDATE_TOKENS_KEY =
+    "de.kisimedia.capacitor-live-activity.cachedUpdateTokens"
 
 private struct UpdateTokenEndpoint: Codable {
     let url: String
@@ -22,15 +24,19 @@ private struct UpdateTokenEndpoint: Codable {
     private var pushTokenObservationDisabledActivityIds = Set<String>()
     private var updateTokenEndpoint: UpdateTokenEndpoint?
     private var updateTokenHeaders: [String: String] = [:]
+    private var cachedUpdateTokens: [String: [String: String]] = [:]
     private let activitiesQueue = DispatchQueue(
         label: "de.kisimedia.capacitor-live-activity.activities")
     private let endpointQueue = DispatchQueue(
         label: "de.kisimedia.capacitor-live-activity.update-token-endpoint")
+    private let tokenCacheQueue = DispatchQueue(
+        label: "de.kisimedia.capacitor-live-activity.update-token-cache")
     weak var plugin: CAPPlugin?
 
     override public init() {
         super.init()
         updateTokenEndpoint = Self.loadUpdateTokenEndpoint()
+        cachedUpdateTokens = Self.loadCachedUpdateTokens()
 
         Task {
             for activity in Activity<GenericAttributes>.activities {
@@ -85,6 +91,21 @@ private struct UpdateTokenEndpoint: Codable {
                 "url": endpoint.url,
                 "headers": updateTokenHeaders,
             ]
+        }
+    }
+
+    @objc public func getActivityPushTokens(id: String?) -> [[String: String]] {
+        tokenCacheQueue.sync {
+            let tokens = cachedUpdateTokens.values
+                .filter { token in
+                    guard let id else { return true }
+                    return token["id"] == id
+                }
+                .sorted { left, right in
+                    (left["activityId"] ?? "") < (right["activityId"] ?? "")
+                }
+
+            return Array(tokens)
         }
     }
 
@@ -431,9 +452,21 @@ private struct UpdateTokenEndpoint: Codable {
             "activityId": activityId,
             "token": token,
         ]
+        cacheUpdateToken(id: id, activityId: activityId, token: token)
 
         plugin?.notifyListeners(EVT_PUSH_TOKEN, data: payload)
         await registerUpdateToken(payload: payload)
+    }
+
+    private func cacheUpdateToken(id: String, activityId: String, token: String) {
+        tokenCacheQueue.sync {
+            cachedUpdateTokens[activityId] = [
+                "id": id,
+                "activityId": activityId,
+                "token": token,
+            ]
+            Self.saveCachedUpdateTokens(cachedUpdateTokens)
+        }
     }
 
     private func registerUpdateToken(payload: [String: Any]) async {
@@ -486,6 +519,19 @@ private struct UpdateTokenEndpoint: Codable {
     private static func saveUpdateTokenEndpoint(_ endpoint: UpdateTokenEndpoint) {
         guard let data = try? JSONEncoder().encode(endpoint) else { return }
         UserDefaults.standard.set(data, forKey: UPDATE_TOKEN_ENDPOINT_KEY)
+    }
+
+    private static func loadCachedUpdateTokens() -> [String: [String: String]] {
+        guard let data = UserDefaults.standard.data(forKey: CACHED_UPDATE_TOKENS_KEY) else {
+            return [:]
+        }
+
+        return (try? JSONDecoder().decode([String: [String: String]].self, from: data)) ?? [:]
+    }
+
+    private static func saveCachedUpdateTokens(_ tokens: [String: [String: String]]) {
+        guard let data = try? JSONEncoder().encode(tokens) else { return }
+        UserDefaults.standard.set(data, forKey: CACHED_UPDATE_TOKENS_KEY)
     }
 
     private static func isLoopbackHost(_ host: String?) -> Bool {

--- a/ios/Sources/LiveActivityPlugin/LiveActivity.swift
+++ b/ios/Sources/LiveActivityPlugin/LiveActivity.swift
@@ -45,6 +45,13 @@ private struct CachedUpdateToken: Codable {
         super.init()
         updateTokenEndpoint = Self.loadUpdateTokenEndpoint()
         cachedUpdateTokens = Self.loadCachedUpdateTokens()
+        tokenCacheQueue.sync {
+            let prunedTokens = Self.prunedCachedUpdateTokens(cachedUpdateTokens)
+            if prunedTokens.count != cachedUpdateTokens.count {
+                cachedUpdateTokens = prunedTokens
+                Self.saveCachedUpdateTokens(cachedUpdateTokens)
+            }
+        }
 
         Task {
             for activity in Activity<GenericAttributes>.activities {
@@ -476,6 +483,13 @@ private struct CachedUpdateToken: Codable {
 
     private func cacheUpdateToken(id: String, activityId: String, token: String) {
         tokenCacheQueue.sync {
+            if let existing = cachedUpdateTokens[activityId],
+                existing.id == id,
+                existing.token == token
+            {
+                return
+            }
+
             cachedUpdateTokens[activityId] = CachedUpdateToken(
                 id: id,
                 activityId: activityId,
@@ -490,17 +504,7 @@ private struct CachedUpdateToken: Codable {
     private func pruneCachedUpdateTokens() {
         guard cachedUpdateTokens.count > Self.maxCachedUpdateTokens else { return }
 
-        cachedUpdateTokens = Dictionary(
-            uniqueKeysWithValues: cachedUpdateTokens.values
-                .sorted { left, right in
-                    if left.cachedAt == right.cachedAt {
-                        return left.activityId > right.activityId
-                    }
-                    return left.cachedAt > right.cachedAt
-                }
-                .prefix(Self.maxCachedUpdateTokens)
-                .map { ($0.activityId, $0) }
-        )
+        cachedUpdateTokens = Self.prunedCachedUpdateTokens(cachedUpdateTokens)
     }
 
     private func registerUpdateToken(payload: [String: Any]) async {
@@ -592,7 +596,18 @@ private struct CachedUpdateToken: Codable {
     }
 
     private static func saveCachedUpdateTokens(_ tokens: [String: CachedUpdateToken]) {
-        let prunedTokens = Dictionary(
+        let prunedTokens = prunedCachedUpdateTokens(tokens)
+
+        guard let data = try? JSONEncoder().encode(prunedTokens) else { return }
+        UserDefaults.standard.set(data, forKey: CACHED_UPDATE_TOKENS_KEY)
+    }
+
+    private static func prunedCachedUpdateTokens(
+        _ tokens: [String: CachedUpdateToken]
+    ) -> [String: CachedUpdateToken] {
+        guard tokens.count > maxCachedUpdateTokens else { return tokens }
+
+        return Dictionary(
             uniqueKeysWithValues: tokens.values
                 .sorted { left, right in
                     if left.cachedAt == right.cachedAt {
@@ -603,9 +618,6 @@ private struct CachedUpdateToken: Codable {
                 .prefix(maxCachedUpdateTokens)
                 .map { ($0.activityId, $0) }
         )
-
-        guard let data = try? JSONEncoder().encode(prunedTokens) else { return }
-        UserDefaults.standard.set(data, forKey: CACHED_UPDATE_TOKENS_KEY)
     }
 
     private static func isLoopbackHost(_ host: String?) -> Bool {

--- a/ios/Sources/LiveActivityPlugin/LiveActivity.swift
+++ b/ios/Sources/LiveActivityPlugin/LiveActivity.swift
@@ -14,8 +14,16 @@ private struct UpdateTokenEndpoint: Codable {
     let url: String
 }
 
+private struct CachedUpdateToken: Codable {
+    let id: String
+    let activityId: String
+    let token: String
+    let cachedAt: TimeInterval
+}
+
 @available(iOS 16.2, *)
 @objc public class LiveActivity: NSObject {
+    private static let maxCachedUpdateTokens = 50
     private var activities: [String: Activity<GenericAttributes>] = [:]
     private var activityOrder: [String] = []
     private var observedTokenActivityIds = Set<String>()
@@ -24,7 +32,7 @@ private struct UpdateTokenEndpoint: Codable {
     private var pushTokenObservationDisabledActivityIds = Set<String>()
     private var updateTokenEndpoint: UpdateTokenEndpoint?
     private var updateTokenHeaders: [String: String] = [:]
-    private var cachedUpdateTokens: [String: [String: String]] = [:]
+    private var cachedUpdateTokens: [String: CachedUpdateToken] = [:]
     private let activitiesQueue = DispatchQueue(
         label: "de.kisimedia.capacitor-live-activity.activities")
     private let endpointQueue = DispatchQueue(
@@ -96,16 +104,24 @@ private struct UpdateTokenEndpoint: Codable {
 
     @objc public func getActivityPushTokens(id: String?) -> [[String: String]] {
         tokenCacheQueue.sync {
-            let tokens = cachedUpdateTokens.values
+            cachedUpdateTokens.values
                 .filter { token in
                     guard let id else { return true }
-                    return token["id"] == id
+                    return token.id == id
                 }
                 .sorted { left, right in
-                    (left["activityId"] ?? "") < (right["activityId"] ?? "")
+                    if left.cachedAt == right.cachedAt {
+                        return left.activityId < right.activityId
+                    }
+                    return left.cachedAt < right.cachedAt
                 }
-
-            return Array(tokens)
+                .map { token in
+                    [
+                        "id": token.id,
+                        "activityId": token.activityId,
+                        "token": token.token,
+                    ]
+                }
         }
     }
 
@@ -460,13 +476,31 @@ private struct UpdateTokenEndpoint: Codable {
 
     private func cacheUpdateToken(id: String, activityId: String, token: String) {
         tokenCacheQueue.sync {
-            cachedUpdateTokens[activityId] = [
-                "id": id,
-                "activityId": activityId,
-                "token": token,
-            ]
+            cachedUpdateTokens[activityId] = CachedUpdateToken(
+                id: id,
+                activityId: activityId,
+                token: token,
+                cachedAt: Date().timeIntervalSince1970
+            )
+            pruneCachedUpdateTokens()
             Self.saveCachedUpdateTokens(cachedUpdateTokens)
         }
+    }
+
+    private func pruneCachedUpdateTokens() {
+        guard cachedUpdateTokens.count > Self.maxCachedUpdateTokens else { return }
+
+        cachedUpdateTokens = Dictionary(
+            uniqueKeysWithValues: cachedUpdateTokens.values
+                .sorted { left, right in
+                    if left.cachedAt == right.cachedAt {
+                        return left.activityId > right.activityId
+                    }
+                    return left.cachedAt > right.cachedAt
+                }
+                .prefix(Self.maxCachedUpdateTokens)
+                .map { ($0.activityId, $0) }
+        )
     }
 
     private func registerUpdateToken(payload: [String: Any]) async {
@@ -521,16 +555,56 @@ private struct UpdateTokenEndpoint: Codable {
         UserDefaults.standard.set(data, forKey: UPDATE_TOKEN_ENDPOINT_KEY)
     }
 
-    private static func loadCachedUpdateTokens() -> [String: [String: String]] {
+    private static func loadCachedUpdateTokens() -> [String: CachedUpdateToken] {
         guard let data = UserDefaults.standard.data(forKey: CACHED_UPDATE_TOKENS_KEY) else {
             return [:]
         }
 
-        return (try? JSONDecoder().decode([String: [String: String]].self, from: data)) ?? [:]
+        if let tokens = try? JSONDecoder().decode([String: CachedUpdateToken].self, from: data) {
+            return tokens
+        }
+
+        guard let legacyTokens = try? JSONDecoder().decode(
+            [String: [String: String]].self, from: data)
+        else {
+            return [:]
+        }
+
+        return Dictionary(
+            uniqueKeysWithValues: legacyTokens.compactMap { activityId, token in
+                guard let id = token["id"],
+                    let tokenActivityId = token["activityId"],
+                    let tokenValue = token["token"]
+                else {
+                    return nil
+                }
+
+                return (
+                    activityId,
+                    CachedUpdateToken(
+                        id: id,
+                        activityId: tokenActivityId,
+                        token: tokenValue,
+                        cachedAt: 0
+                    )
+                )
+            })
     }
 
-    private static func saveCachedUpdateTokens(_ tokens: [String: [String: String]]) {
-        guard let data = try? JSONEncoder().encode(tokens) else { return }
+    private static func saveCachedUpdateTokens(_ tokens: [String: CachedUpdateToken]) {
+        let prunedTokens = Dictionary(
+            uniqueKeysWithValues: tokens.values
+                .sorted { left, right in
+                    if left.cachedAt == right.cachedAt {
+                        return left.activityId > right.activityId
+                    }
+                    return left.cachedAt > right.cachedAt
+                }
+                .prefix(maxCachedUpdateTokens)
+                .map { ($0.activityId, $0) }
+        )
+
+        guard let data = try? JSONEncoder().encode(prunedTokens) else { return }
         UserDefaults.standard.set(data, forKey: CACHED_UPDATE_TOKENS_KEY)
     }
 

--- a/ios/Sources/LiveActivityPlugin/LiveActivityPlugin.swift
+++ b/ios/Sources/LiveActivityPlugin/LiveActivityPlugin.swift
@@ -19,6 +19,7 @@ public class LiveActivityPlugin: CAPPlugin, CAPBridgedPlugin {
         CAPPluginMethod(name: "listActivities", returnType: CAPPluginReturnPromise),
         CAPPluginMethod(name: "observePushToStartToken", returnType: CAPPluginReturnPromise),
         CAPPluginMethod(name: "setUpdateTokenEndpoint", returnType: CAPPluginReturnPromise),
+        CAPPluginMethod(name: "getActivityPushTokens", returnType: CAPPluginReturnPromise),
     ]
 
     private let implementation = LiveActivity()
@@ -210,5 +211,10 @@ public class LiveActivityPlugin: CAPPlugin, CAPBridgedPlugin {
         } catch {
             call.reject(error.localizedDescription)
         }
+    }
+
+    @objc func getActivityPushTokens(_ call: CAPPluginCall) {
+        let id = call.getString("id")
+        call.resolve(["items": implementation.getActivityPushTokens(id: id)])
     }
 }

--- a/ios/Tests/LiveActivityPluginTests/LiveActivityPluginTests.swift
+++ b/ios/Tests/LiveActivityPluginTests/LiveActivityPluginTests.swift
@@ -167,6 +167,32 @@ final class LiveActivityPluginTests: XCTestCase {
         }
     }
 
+    func testGetActivityPushTokensPrunesPersistedCacheOnStartup() throws {
+        if #available(iOS 16.2, *) {
+            let cachedTokens = Dictionary(
+                uniqueKeysWithValues: (0..<55).map { index in
+                    (
+                        "activity-\(index)",
+                        [
+                            "id": "logical-\(index)",
+                            "activityId": "activity-\(index)",
+                            "token": "token-\(index)",
+                            "cachedAt": Double(index),
+                        ] as [String: Any]
+                    )
+                })
+            let data = try JSONSerialization.data(withJSONObject: cachedTokens)
+            UserDefaults.standard.set(data, forKey: cachedUpdateTokensKey)
+
+            let reloadedPlugin = LiveActivity()
+            let tokens = reloadedPlugin.getActivityPushTokens(id: nil)
+
+            XCTAssertEqual(tokens.count, 50)
+            XCTAssertNil(tokens.first { $0["activityId"] == "activity-0" })
+            XCTAssertNotNil(tokens.first { $0["activityId"] == "activity-54" })
+        }
+    }
+
     func testStartAndGetCurrent() async throws {
         if #available(iOS 16.2, *) {
             try skipIfActivitiesUnavailable()

--- a/ios/Tests/LiveActivityPluginTests/LiveActivityPluginTests.swift
+++ b/ios/Tests/LiveActivityPluginTests/LiveActivityPluginTests.swift
@@ -140,6 +140,25 @@ final class LiveActivityPluginTests: XCTestCase {
         }
     }
 
+    func testGetActivityPushTokensMigratesLegacyTokensUsingDictionaryKeyActivityId() throws {
+        if #available(iOS 16.2, *) {
+            let cachedTokens = [
+                "activity-key": [
+                    "id": "logical-1",
+                    "token": "abc123",
+                ]
+            ]
+            let data = try JSONEncoder().encode(cachedTokens)
+            UserDefaults.standard.set(data, forKey: cachedUpdateTokensKey)
+
+            let reloadedPlugin = LiveActivity()
+            let token = reloadedPlugin.getActivityPushTokens(id: "logical-1").first
+
+            XCTAssertEqual(token?["activityId"], "activity-key")
+            XCTAssertEqual(token?["token"], "abc123")
+        }
+    }
+
     func testGetActivityPushTokensSortsByCachedAtWithoutExposingTimestamp() throws {
         if #available(iOS 16.2, *) {
             let cachedTokens: [String: [String: Any]] = [

--- a/ios/Tests/LiveActivityPluginTests/LiveActivityPluginTests.swift
+++ b/ios/Tests/LiveActivityPluginTests/LiveActivityPluginTests.swift
@@ -140,6 +140,33 @@ final class LiveActivityPluginTests: XCTestCase {
         }
     }
 
+    func testGetActivityPushTokensSortsByCachedAtWithoutExposingTimestamp() throws {
+        if #available(iOS 16.2, *) {
+            let cachedTokens: [String: [String: Any]] = [
+                "activity-new": [
+                    "id": "logical-1",
+                    "activityId": "activity-new",
+                    "token": "new-token",
+                    "cachedAt": 200.0,
+                ],
+                "activity-old": [
+                    "id": "logical-1",
+                    "activityId": "activity-old",
+                    "token": "old-token",
+                    "cachedAt": 100.0,
+                ],
+            ]
+            let data = try JSONSerialization.data(withJSONObject: cachedTokens)
+            UserDefaults.standard.set(data, forKey: cachedUpdateTokensKey)
+
+            let reloadedPlugin = LiveActivity()
+            let tokens = reloadedPlugin.getActivityPushTokens(id: "logical-1")
+
+            XCTAssertEqual(tokens.map { $0["token"] }, ["old-token", "new-token"])
+            XCTAssertNil(tokens.last?["cachedAt"])
+        }
+    }
+
     func testStartAndGetCurrent() async throws {
         if #available(iOS 16.2, *) {
             try skipIfActivitiesUnavailable()

--- a/ios/Tests/LiveActivityPluginTests/LiveActivityPluginTests.swift
+++ b/ios/Tests/LiveActivityPluginTests/LiveActivityPluginTests.swift
@@ -7,16 +7,20 @@ import XCTest
 final class LiveActivityPluginTests: XCTestCase {
     private let updateTokenEndpointKey =
         "de.kisimedia.capacitor-live-activity.updateTokenEndpoint"
+    private let cachedUpdateTokensKey =
+        "de.kisimedia.capacitor-live-activity.cachedUpdateTokens"
     var plugin: LiveActivity!
 
     override func setUp() {
         super.setUp()
         UserDefaults.standard.removeObject(forKey: updateTokenEndpointKey)
+        UserDefaults.standard.removeObject(forKey: cachedUpdateTokensKey)
         plugin = LiveActivity()
     }
 
     override func tearDown() {
         UserDefaults.standard.removeObject(forKey: updateTokenEndpointKey)
+        UserDefaults.standard.removeObject(forKey: cachedUpdateTokensKey)
         super.tearDown()
     }
 
@@ -106,6 +110,33 @@ final class LiveActivityPluginTests: XCTestCase {
                 "https://example.com/live-activity/register-token"
             )
             XCTAssertEqual((endpoint?["headers"] as? [String: String])?.isEmpty, true)
+        }
+    }
+
+    func testGetActivityPushTokensReturnsPersistedTokens() throws {
+        if #available(iOS 16.2, *) {
+            let cachedTokens = [
+                "activity-1": [
+                    "id": "logical-1",
+                    "activityId": "activity-1",
+                    "token": "abc123",
+                ],
+                "activity-2": [
+                    "id": "logical-2",
+                    "activityId": "activity-2",
+                    "token": "def456",
+                ],
+            ]
+            let data = try JSONEncoder().encode(cachedTokens)
+            UserDefaults.standard.set(data, forKey: cachedUpdateTokensKey)
+
+            let reloadedPlugin = LiveActivity()
+
+            XCTAssertEqual(reloadedPlugin.getActivityPushTokens(id: nil).count, 2)
+            XCTAssertEqual(
+                reloadedPlugin.getActivityPushTokens(id: "logical-2").first?["token"],
+                "def456"
+            )
         }
     }
 

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -133,6 +133,19 @@ export interface LiveActivityPlugin {
    */
   setUpdateTokenEndpoint(options: UpdateTokenEndpointOptions): Promise<void>;
 
+  /**
+   * Return cached per-activity update tokens that iOS has already received.
+   *
+   * Use this as a fallback when `liveActivityPushToken` was emitted while the
+   * WebView was not running, for example after a Live Activity was started via
+   * push-to-start in the background. Pass `id` to filter by your logical
+   * activity id.
+   *
+   * @since 8.2.0
+   * @platform iOS
+   */
+  getActivityPushTokens(options?: { id?: string }): Promise<GetActivityPushTokensResult>;
+
   // ---------- Events ----------
 
   /**
@@ -393,6 +406,15 @@ export interface ListActivitiesResult {
     /** ActivityKit state as a string ("active" | "stale" | "pending" | "ended" | "dismissed"). */
     state: string;
   }[];
+}
+
+/**
+ * Result of listing cached per-activity update tokens.
+ * @since 8.2.0
+ * @platform iOS
+ */
+export interface GetActivityPushTokensResult {
+  items: PushTokenEvent[];
 }
 
 /**

--- a/src/web.ts
+++ b/src/web.ts
@@ -11,6 +11,7 @@ import type {
   EndActivityOptions,
   LiveActivityState,
   ListActivitiesResult,
+  GetActivityPushTokensResult,
   UpdateTokenEndpointOptions,
 } from './definitions';
 
@@ -65,5 +66,10 @@ export class LiveActivityWeb extends WebPlugin implements LiveActivityPlugin {
 
   async setUpdateTokenEndpoint(_options: UpdateTokenEndpointOptions): Promise<void> {
     console.warn('[LiveActivity] setUpdateTokenEndpoint is only available on iOS.');
+  }
+
+  async getActivityPushTokens(): Promise<GetActivityPushTokensResult> {
+    console.warn('[LiveActivity] getActivityPushTokens is only available on iOS.');
+    return { items: [] };
   }
 }

--- a/src/web.ts
+++ b/src/web.ts
@@ -68,7 +68,7 @@ export class LiveActivityWeb extends WebPlugin implements LiveActivityPlugin {
     console.warn('[LiveActivity] setUpdateTokenEndpoint is only available on iOS.');
   }
 
-  async getActivityPushTokens(): Promise<GetActivityPushTokensResult> {
+  async getActivityPushTokens(_options?: { id?: string }): Promise<GetActivityPushTokensResult> {
     console.warn('[LiveActivity] getActivityPushTokens is only available on iOS.');
     return { items: [] };
   }


### PR DESCRIPTION
This pull request introduces a new feature that allows JavaScript to retrieve cached per-activity update tokens on iOS, ensuring that push tokens received while the WebView was not running (such as during push-to-start flows) can be accessed later. The update includes native iOS implementation, TypeScript definitions, documentation, and example app/demo updates. Additionally, a new test ensures the persistence and retrieval of cached tokens.

As mentioned here: https://github.com/kisimediaDE/capacitor-live-activity/issues/13

**New API for Cached Activity Push Tokens:**

* Added a new method `getActivityPushTokens(...)` to the iOS plugin, allowing retrieval of cached per-activity update tokens that were received while the WebView was not running. This covers scenarios where the `liveActivityPushToken` event was missed. The implementation includes thread-safe caching, persistence using `UserDefaults`, and filtering by logical activity id. [[1]](diffhunk://#diff-536450ed13b0a15be38aa38f18fe27ea67ec13546f2ada0e8d71758b1d07fc3dR10-R11) [[2]](diffhunk://#diff-536450ed13b0a15be38aa38f18fe27ea67ec13546f2ada0e8d71758b1d07fc3dR27-R39) [[3]](diffhunk://#diff-536450ed13b0a15be38aa38f18fe27ea67ec13546f2ada0e8d71758b1d07fc3dR97-R111) [[4]](diffhunk://#diff-536450ed13b0a15be38aa38f18fe27ea67ec13546f2ada0e8d71758b1d07fc3dR455-R471) [[5]](diffhunk://#diff-536450ed13b0a15be38aa38f18fe27ea67ec13546f2ada0e8d71758b1d07fc3dR524-R536) [[6]](diffhunk://#diff-99eafc706bcf2135bdc83f5b4fee9f0cbed88c43b9249996577d2dafecb29cddR22) [[7]](diffhunk://#diff-99eafc706bcf2135bdc83f5b4fee9f0cbed88c43b9249996577d2dafecb29cddR215-R219)

* Added a new interface `GetActivityPushTokensResult` and updated TypeScript definitions to reflect the new API, ensuring type safety and documentation for the new method. [[1]](diffhunk://#diff-f1f3c6677661c21128a30f64358c6615c6801043e1cbfcc904302422a17b3246R136-R148) [[2]](diffhunk://#diff-f1f3c6677661c21128a30f64358c6615c6801043e1cbfcc904302422a17b3246R411-R419) [[3]](diffhunk://#diff-248af8fc04398409c31555c8c23d55f57ee2c34fa828e420e66ed9ebbae08894R14) [[4]](diffhunk://#diff-248af8fc04398409c31555c8c23d55f57ee2c34fa828e420e66ed9ebbae08894R70-R74)

**Documentation and Example App Enhancements:**

* Updated `README.md` to document the new `getActivityPushTokens(...)` API, including usage examples, method reference, and return types. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R282-R288) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R317) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R547-R570) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L698-R736) [[5]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R750-R756)

* Enhanced the example app's Push demo with new controls and UI for registering the update token endpoint and loading cached activity tokens, along with corresponding JavaScript handlers. [[1]](diffhunk://#diff-3971f7401aed783fa4f012fcba869304f790dd77283f49d5b8dc1b8a63085eb6R39-R40) [[2]](diffhunk://#diff-7d87047fe3c60e43ab0612c8a8f292d691b48b778570750713b5fa37f05321d7R91-R120)

**Testing:**

* Added a new unit test to verify that cached activity push tokens are persisted and can be retrieved, including filtering by logical activity id. [[1]](diffhunk://#diff-dcd474a076a6b8ee0a64c84fcdffe640ea1f87e87d2f204a80689c3508f2efcbR10-R23) [[2]](diffhunk://#diff-dcd474a076a6b8ee0a64c84fcdffe640ea1f87e87d2f204a80689c3508f2efcbR116-R142)

**Changelog:**

* Updated `CHANGELOG.md` to reflect the addition of the cached activity push tokens feature and the new demo controls in the example app.